### PR TITLE
Added the method 'GetRandomColorExact' to be able to use the ColorHelper for example in LINQ and other places where it has to be more exact

### DIFF
--- a/ColorHelper.Tests/Generator/ColorGenerator.cs
+++ b/ColorHelper.Tests/Generator/ColorGenerator.cs
@@ -39,7 +39,7 @@ namespace ConsoleHelper.Tests
             var result = ColorGenerator.GetRandomColor<HSL>();
             Assert.NotNull((HSL)result);
         }
-        
+
         [Test]
         public void GetRandomColorXyz()
         {
@@ -62,6 +62,34 @@ namespace ConsoleHelper.Tests
         public void GetDarkRandomColor()
         {
             var result = ColorGenerator.GetDarkRandomColor<RGB>();
+            Assert.That(result.R, Is.LessThanOrEqualTo(80));
+            Assert.That(result.G, Is.LessThanOrEqualTo(80));
+            Assert.That(result.B, Is.LessThanOrEqualTo(80));
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void GetRandomColorExact()
+        {
+            var result = ColorGenerator.GetRandomColorExact<RGB>("helloworld".GetHashCode());
+            Assert.NotNull((RGB)result);
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void GetRandomColorExactLight()
+        {
+            var result = ColorGenerator.GetRandomColorExact<RGB>("helloworld".GetHashCode(), ColorGenerator.ColorThemesEnum.Light);
+            Assert.That(result.R, Is.GreaterThanOrEqualTo(170));
+            Assert.That(result.G, Is.GreaterThanOrEqualTo(170));
+            Assert.That(result.B, Is.GreaterThanOrEqualTo(170));
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void GetRandomColorExactDark()
+        {
+            var result = ColorGenerator.GetRandomColorExact<RGB>("helloworld".GetHashCode(), ColorGenerator.ColorThemesEnum.Dark);
             Assert.That(result.R, Is.LessThanOrEqualTo(80));
             Assert.That(result.G, Is.LessThanOrEqualTo(80));
             Assert.That(result.B, Is.LessThanOrEqualTo(80));

--- a/ColorHelper/Color/ColorThemesEnum.cs
+++ b/ColorHelper/Color/ColorThemesEnum.cs
@@ -1,0 +1,12 @@
+﻿namespace ColorHelper
+{
+    public static partial class ColorGenerator
+    {
+        public enum ColorThemesEnum
+        {
+            Default,
+            Light,
+            Dark
+        }
+    }
+}

--- a/ColorHelper/Generator/ColorGenerator.cs
+++ b/ColorHelper/Generator/ColorGenerator.cs
@@ -2,46 +2,73 @@
 
 namespace ColorHelper
 {
-    public static class ColorGenerator
+    public static partial class ColorGenerator
     {
         public static T GetRandomColor<T>() where T: IColor
         {
-            return GetRandomColor<T>(new RgbRandomColorFilter());
+            return GetRandomColor<T>(GetColorFilter(ColorThemesEnum.Default));
         }
 
         public static T GetLightRandomColor<T>() where T : IColor
         {
-            const byte minRangeValue = 170;
-
-            RgbRandomColorFilter filter = new RgbRandomColorFilter();
-            filter.minR = minRangeValue;
-            filter.minG = minRangeValue;
-            filter.minB = minRangeValue;
-
-            return GetRandomColor<T>(filter);
+            return GetRandomColor<T>(GetColorFilter(ColorThemesEnum.Light));
         }
 
         public static T GetDarkRandomColor<T>() where T : IColor
         {
+            return GetRandomColor<T>(GetColorFilter(ColorThemesEnum.Dark));
+        }
+
+        public static T GetRandomColorExact<T>(int hashCode, ColorThemesEnum colorTheme = ColorThemesEnum.Default) where T : IColor
+        {
+            return GetRandomColorExact<T>(hashCode, GetColorFilter(colorTheme));
+        }
+
+        private static RgbRandomColorFilter GetColorFilter(ColorThemesEnum colorTheme)
+        {
             const byte maxRangeValue = 80;
+            const byte minRangeValue = 170;
 
             RgbRandomColorFilter filter = new RgbRandomColorFilter();
-            filter.maxR = maxRangeValue;
-            filter.maxG = maxRangeValue;
-            filter.maxB = maxRangeValue;
 
-            return GetRandomColor<T>(filter);
+            switch (colorTheme)
+            {
+                case ColorThemesEnum.Default:
+                    break;
+                case ColorThemesEnum.Light:
+                    filter.minR = minRangeValue;
+                    filter.minG = minRangeValue;
+                    filter.minB = minRangeValue;
+                    break;
+                case ColorThemesEnum.Dark:
+                    filter.maxR = maxRangeValue;
+                    filter.maxG = maxRangeValue;
+                    filter.maxB = maxRangeValue;
+                    break;
+            }
+
+            return filter;
         }
 
         private static T GetRandomColor<T>(RgbRandomColorFilter filter) where T : IColor
         {
             Random random = new Random(DateTime.Now.Millisecond);
+            return GetRandomColor<T>(filter, random);
+        }
 
+        private static T GetRandomColorExact<T>(int hashCode, RgbRandomColorFilter filter) where T : IColor
+        {
+            Random random = new Random(DateTime.Now.Millisecond + hashCode);
+            return GetRandomColor<T>(filter, random);
+        }
+
+        private static T GetRandomColor<T>(RgbRandomColorFilter filter, Random random) where T : IColor
+        {
             RGB rgb = new RGB(
                 (byte)random.Next(filter.minR, filter.maxR),
                 (byte)random.Next(filter.minG, filter.maxG),
                 (byte)random.Next(filter.minB, filter.maxB));
-            
+
             return ConvertRgbToNecessaryColorType<T>(rgb);
         }
 


### PR DESCRIPTION
- the parameter 'hashCode' allows to use additional a hashcode for calculating the random number so its more exact then only using the milliseconds.

- the parameter 'colorTheme' allows to specify a color theme by enum(Default,Light,Dark)