### PR TITLE
Fix hsv to rgb

### DIFF
--- a/ColorHelper.ConsoleDemo/ColorHelper.ConsoleDemo.csproj
+++ b/ColorHelper.ConsoleDemo/ColorHelper.ConsoleDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ColorHelper.Tests/ColorHelper.Tests.csproj
+++ b/ColorHelper.Tests/ColorHelper.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/ColorHelper.Tests/Converter/ColorConverter.cs
+++ b/ColorHelper.Tests/Converter/ColorConverter.cs
@@ -120,6 +120,9 @@ namespace ConsoleHelper.Tests
         {
             var result = ColorConverter.HsvToRgb(new HSV(240, 80, 64));
             Assert.AreEqual(new RGB(32, 32, 162), result);
+
+            result = ColorConverter.HsvToRgb(new HSV(270, 100, 100));
+            Assert.AreEqual(new RGB(128, 0, 255), result);
         }
 
         [Test]

--- a/ColorHelper/ColorHelper.csproj
+++ b/ColorHelper/ColorHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Artyom Gritsuk</Authors>
     <RepositoryUrl>https://github.com/iamartyom/ColorHelper</RepositoryUrl>
     <PackageProjectUrl>https://github.com/iamartyom/ColorHelper</PackageProjectUrl>

--- a/ColorHelper/ColorHelper.csproj
+++ b/ColorHelper/ColorHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Artyom Gritsuk</Authors>
     <RepositoryUrl>https://github.com/iamartyom/ColorHelper</RepositoryUrl>
     <PackageProjectUrl>https://github.com/iamartyom/ColorHelper</PackageProjectUrl>

--- a/ColorHelper/Converter/ColorConverter.cs
+++ b/ColorHelper/Converter/ColorConverter.cs
@@ -270,9 +270,12 @@ namespace ColorHelper
                 r = modifiedL;
                 g = modifiedL;
                 b = modifiedL;
-            }
-
-            return new RGB((byte)Math.Round(r * 255), (byte)Math.Round(g * 255), (byte)Math.Round(b * 255));
+            }      
+            
+            return new RGB(
+                (byte)Math.Round(Math.Round(r * 255, 1)), 
+                (byte)Math.Round(Math.Round(g * 255, 1)),
+                (byte)Math.Round(Math.Round(b * 255, 1)));
         }
 
         private static double GetHue(double p, double q, double t)


### PR DESCRIPTION
Make double round ( 1 decimals then 0 decimals ) to overcome lost of precision, see added unit test:

ex. r=0.49999999999999956 would round (r * 255) to 127 instead of expected 128

Note: other cases could require same approach, I only fixed this one.

*Note* : while library netstandard2.0 its ok, Test and demo frameworks are upgraded from from netcoreapp3.1 to net7 because [out of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) and generates follow error on unix platforms:

```
The active test run was aborted. Reason: Test host process crashed : No usable version of libssl was found
```
